### PR TITLE
Replace ’ with ' to fix "Smart quotes were detected and ignored in yo…

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,13 +1,13 @@
 source 'https://github.com/CocoaPods/Specs.git'
 use_frameworks!
-platform :osx, "10.12”
+platform :osx, '10.12'
 
 target 'Captuocr' do
-	pod 'AsyncSwift’,'~> 2.0.0'
-  	pod 'ReactiveKit’,'~> 3.8.0'
-    pod 'Bond’,'~> 6.5.0'
-	pod 'Alamofire’,'~> 4.5.0'
-    pod 'EVReflection’,'~> 5.2.0'
+    pod 'AsyncSwift','~> 2.0.0'
+    pod 'ReactiveKit','~> 3.8.0'
+    pod 'Bond','~> 6.5.0'
+    pod 'Alamofire','~> 4.5.0'
+    pod 'EVReflection','~> 5.2.0'
     pod 'Swinject', '~> 2.0.0'
     pod 'SwinjectPropertyLoader', '~> 1.0.0'
     pod 'SQLite.swift','~> 0.11.0'


### PR DESCRIPTION
…ur Podfile" warning.

Fixes #8